### PR TITLE
Add separators between grade rows

### DIFF
--- a/apps/web/src/components/grades/grade-list.test.ts
+++ b/apps/web/src/components/grades/grade-list.test.ts
@@ -31,6 +31,7 @@ describe("shared grade list", () => {
     expect(gradesPage).toContain("<GradeList grades={group.grades} />")
     expect(subjectPage).toContain("<GradeList grades={grades} />")
     expect(averagePage).toContain("<GradeList grades={grades} />")
+    expect(component).toContain('<ul className="divide-y">')
     expect(component).toContain('className="flex min-h-12')
     expect(component).toContain("<ChevronRightIcon")
   })

--- a/apps/web/src/components/grades/grade-list.tsx
+++ b/apps/web/src/components/grades/grade-list.tsx
@@ -20,7 +20,7 @@ export function GradeList({ grades }: { grades: readonly Grade[] }) {
   return (
     <Card className="py-2">
       <CardContent className="px-2">
-        <ul>
+        <ul className="divide-y">
           {grades.map((grade) => {
             const subject = graph.byId(grade.subjectId)
 


### PR DESCRIPTION
## What changed

- Added horizontal separators between grade rows through the shared `GradeList` component.
- Kept the existing card and row layout unchanged.
- Extended the regression test to cover the separator styling.

## Why

Grade rows in grouped lists were harder to distinguish visually. The shared component is used in all four locations, so this keeps the treatment consistent across:

- Dashboard recent grades
- Grades timeline
- Subject details
- Average details

## Validation

- `bun test apps/web/src/components/grades/grade-list.test.ts`
- `bun x prettier --check apps/web/src/components/grades/grade-list.tsx apps/web/src/components/grades/grade-list.test.ts`
- `bun run --cwd apps/web lint`
- `bun run --cwd apps/web check-types`
